### PR TITLE
Fix MCP tool schema parameters handling in DeepSeek agent

### DIFF
--- a/deepseek-ai-agent/src/main/java/ru/comavp/Agent.java
+++ b/deepseek-ai-agent/src/main/java/ru/comavp/Agent.java
@@ -209,11 +209,12 @@ public class Agent {
                 .putAdditionalProperty("properties", JsonValue.from(jsonSchema.properties()))
                 .putAdditionalProperty("required", JsonValue.from(Objects.isNull(jsonSchema.required())
                         ? new ArrayList<>() : jsonSchema.required()))
-                /*todo throws com.openai.errors.BadRequestException: 400: Invalid schema for function 'mail-sender': null is not of types "boolean", "object"
-                .putAdditionalProperty("additionalProperties", JsonValue.from(jsonSchema.additionalProperties()))
-                .putAdditionalProperty("$defs", JsonValue.from(jsonSchema.defs()))
-                .putAdditionalProperty("definitions", JsonValue.from(jsonSchema.definitions()))
-                */
+                .putAdditionalProperty("additionalProperties", JsonValue.from(
+                        Objects.nonNull(jsonSchema.additionalProperties()) ? jsonSchema.additionalProperties() : false))
+                .putAdditionalProperty("$defs", JsonValue.from(
+                        Objects.nonNull(jsonSchema.defs()) ? jsonSchema.defs() : Map.of()))
+                .putAdditionalProperty("definitions", JsonValue.from(
+                        Objects.nonNull(jsonSchema.definitions()) ? jsonSchema.definitions() : Map.of()))
                 .build();
     }
 }


### PR DESCRIPTION
- Remove TODO comment with hardcoded error description
- Add null-safe handling for optional JSON schema properties
- Use ternary operators to maintain Fluent API style
- Prevent BadRequestException when additionalProperties, defs, or definitions are null
- Provide sensible defaults: false for additionalProperties, empty Map for defs/definitions