### PR TITLE
[claude-code] Refactor DeepSeek agent MCP tools handling

### DIFF
--- a/deepseek-ai-agent/src/main/java/ru/comavp/Agent.java
+++ b/deepseek-ai-agent/src/main/java/ru/comavp/Agent.java
@@ -5,16 +5,12 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openai.client.OpenAIClient;
 import com.openai.core.JsonValue;
-import com.openai.models.FunctionDefinition;
-import com.openai.models.FunctionParameters;
 import com.openai.models.chat.completions.*;
-import io.modelcontextprotocol.spec.McpSchema;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import ru.comavp.mcp.McpClientRunner;
-import ru.comavp.mcp.McpToolDefinition;
-import ru.comavp.tools.ToolDefinitions;
+import ru.comavp.tools.ToolManager;
 import ru.comavp.tools.model.ToolResult;
 
 import java.util.ArrayList;
@@ -22,8 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @RequiredArgsConstructor
 public class Agent {
@@ -33,11 +27,10 @@ public class Agent {
     private final Supplier<String> userMessage;
 
     private ObjectMapper mapper = new ObjectMapper();
+    private ToolManager toolManager;
 
     public void run() {
-        var mcpToolsResult = mcpClient.getToolsList();
-        var mcpFunctions = getMcpChatFunctions(mcpToolsResult);
-        var mcpFunctionsCallersMap = buildMcpToolsDefinitionsMap(mcpToolsResult);
+        toolManager = new ToolManager(mcpClient);
         List<ChatCompletionMessage> dialog = new ArrayList<>();
         System.out.println("Chat with DeepSeek (use 'ctrl-c' to quit)");
         boolean readUserInput = true;
@@ -57,7 +50,7 @@ public class Agent {
                         .build());
             }
 
-            ChatCompletion response = sendUserMessage(dialog, mcpFunctions);
+            ChatCompletion response = sendUserMessage(dialog);
             if (response == null || CollectionUtils.isEmpty(response.choices())) {
                 System.err.println("Error: No response from DeepSeek");
                 continue;
@@ -70,8 +63,7 @@ public class Agent {
                 readUserInput = true;
             } else if (assistantMessage.toolCalls().isPresent()) {
                 readUserInput = false;
-                ToolResult result = executeTool(assistantMessage.toolCalls().get().get(0).asFunction().function(),
-                        mcpFunctionsCallersMap);
+                ToolResult result = executeTool(assistantMessage.toolCalls().get().get(0).asFunction().function());
                 try {
                     dialog.add(ChatCompletionMessage.builder()
                             .role(JsonValue.from("tool"))
@@ -86,22 +78,9 @@ public class Agent {
         }
     }
 
-    private Map<String, McpToolDefinition> buildMcpToolsDefinitionsMap(McpSchema.ListToolsResult result) {
-       return result.tools()
-               .stream()
-               .map(mcpTool -> new McpSchema.CallToolRequest(mcpTool.name(), mcpTool.inputSchema().properties()))
-               .collect(Collectors.toMap(
-                       McpSchema.CallToolRequest::name,
-                       callToolRequest -> McpToolDefinition.builder()
-                               .name(callToolRequest.name())
-                               .function(mcpClient::executeTool)
-                               .build()
-               ));
-    }
-
-    private ChatCompletion sendUserMessage(List<ChatCompletionMessage> dialog, List<ChatCompletionTool> mcpFunctions) {
+    private ChatCompletion sendUserMessage(List<ChatCompletionMessage> dialog) {
         try {
-            List<ChatCompletionTool> functions = Stream.concat(getChatFunctions().stream(), mcpFunctions.stream()).toList();
+            List<ChatCompletionTool> functions = toolManager.getAllChatCompletionTools();
             return client.chat().completions().create(ChatCompletionCreateParams.builder()
                     .model("deepseek-chat")
                     .maxCompletionTokens(1024)
@@ -134,87 +113,22 @@ public class Agent {
         }
     }
 
-    private ToolResult executeTool(ChatCompletionMessageFunctionToolCall.Function functionCall,
-                                   Map<String, McpToolDefinition> mcpFunctions) {
+    private ToolResult executeTool(ChatCompletionMessageFunctionToolCall.Function functionCall) {
         String toolName = functionCall.name();
-        JsonValue arguments = null;
+        Map<String, Object> arguments;
         try {
-            arguments = JsonValue.from(mapper.readTree(functionCall.arguments()));
+            arguments = mapper.readValue(functionCall.arguments(), new TypeReference<Map<String, Object>>() {});
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Error during parsing tool params", e);
         }
-        var functionOpt = Stream.of(ToolDefinitions.values())
-                .filter(item -> item.getName().equals(toolName))
-                .findFirst();
-
-        if (functionOpt.isPresent()) {
-            try {
-                System.out.printf("\u001b[92mtool\u001b[0m: %s(%s)%n", toolName, arguments);
-                return ToolResult.success(functionOpt.get()
-                        .getFunction()
-                        .apply(arguments));
-            } catch (Exception e) {
-                System.out.printf("\u001b[91mError executing tool\u001b[0m: %s%n", e.getMessage());
-                return ToolResult.error("Error: " + e.getMessage());
-            }
-        } else if (mcpFunctions.containsKey(toolName)) {
-            var mcpToolDefinition = mcpFunctions.get(toolName);
-            var mcpToolCaller = mcpToolDefinition.getFunction();
-            try {
-                System.out.printf("\u001b[92mtool\u001b[0m: %s(%s)%n", toolName, arguments);
-                return mapMcpToolCallResult(mcpToolCaller.apply(new McpSchema.CallToolRequest(toolName,
-                        arguments.convert(new TypeReference<Map<String, Object>>() {}))));
-            } catch (Exception e) {
-                System.out.printf("\u001b[91mError executing tool\u001b[0m: %s%n", e.getMessage());
-                return ToolResult.error("Error: " + e.getMessage());
-            }
-        } else {
-            System.out.printf("\u001b[91mError\u001b[0m: Tool '%s' not found%n", toolName);
-            return ToolResult.error("Функция не найдена");
+        
+        try {
+            System.out.printf("\u001b[92mtool\u001b[0m: %s(%s)%n", toolName, arguments.toString());
+            return toolManager.executeTool(toolName, arguments);
+        } catch (Exception e) {
+            System.out.printf("\u001b[91mError executing tool\u001b[0m: %s%n", e.getMessage());
+            return ToolResult.error("Error: " + e.getMessage());
         }
     }
 
-    private ToolResult mapMcpToolCallResult(McpSchema.CallToolResult callToolResult) {
-        return new ToolResult("Вызов MCP тула завершен", callToolResult.isError());
-    }
-
-    private List<ChatCompletionTool> getChatFunctions() {
-        return Stream.of(ToolDefinitions.values())
-                .map(toolDefinition -> ChatCompletionTool.ofFunction(ChatCompletionFunctionTool.builder()
-                        .function(FunctionDefinition.builder()
-                                .name(toolDefinition.getName())
-                                .description(toolDefinition.getDescription())
-                                .parameters(toolDefinition.getParameters())
-                                .build())
-                        .build()))
-                .toList();
-    }
-
-    private List<ChatCompletionTool> getMcpChatFunctions(McpSchema.ListToolsResult mcpTools) {
-        return mcpTools.tools()
-                .stream()
-                .map(mcpTool -> ChatCompletionTool.ofFunction(ChatCompletionFunctionTool.builder()
-                        .function(FunctionDefinition.builder()
-                                .name(mcpTool.name())
-                                .description(mcpTool.description())
-                                .parameters(mapMcpToolParamsToChatFunctionParams(mcpTool.inputSchema()))
-                                .build())
-                        .build()))
-                .toList();
-    }
-
-    private FunctionParameters mapMcpToolParamsToChatFunctionParams(McpSchema.JsonSchema jsonSchema) {
-        return FunctionParameters.builder()
-                .putAdditionalProperty("type", JsonValue.from(jsonSchema.type()))
-                .putAdditionalProperty("properties", JsonValue.from(jsonSchema.properties()))
-                .putAdditionalProperty("required", JsonValue.from(Objects.isNull(jsonSchema.required())
-                        ? new ArrayList<>() : jsonSchema.required()))
-                .putAdditionalProperty("additionalProperties", JsonValue.from(
-                        Objects.nonNull(jsonSchema.additionalProperties()) ? jsonSchema.additionalProperties() : false))
-                .putAdditionalProperty("$defs", JsonValue.from(
-                        Objects.nonNull(jsonSchema.defs()) ? jsonSchema.defs() : Map.of()))
-                .putAdditionalProperty("definitions", JsonValue.from(
-                        Objects.nonNull(jsonSchema.definitions()) ? jsonSchema.definitions() : Map.of()))
-                .build();
-    }
 }

--- a/deepseek-ai-agent/src/main/java/ru/comavp/tools/ToolDefinitions.java
+++ b/deepseek-ai-agent/src/main/java/ru/comavp/tools/ToolDefinitions.java
@@ -55,4 +55,8 @@ public enum ToolDefinitions {
     public Function<JsonValue, String> getFunction() {
         return value.getFunction();
     }
+
+    public ToolDefinition getToolDefinition() {
+        return value;
+    }
 }

--- a/deepseek-ai-agent/src/main/java/ru/comavp/tools/ToolManager.java
+++ b/deepseek-ai-agent/src/main/java/ru/comavp/tools/ToolManager.java
@@ -1,0 +1,61 @@
+package ru.comavp.tools;
+
+import com.openai.models.chat.completions.ChatCompletionTool;
+import io.modelcontextprotocol.spec.McpSchema;
+import ru.comavp.mcp.McpClientRunner;
+import ru.comavp.tools.adapters.LocalToolAdapter;
+import ru.comavp.tools.adapters.McpToolAdapter;
+import ru.comavp.tools.adapters.ToolAdapter;
+import ru.comavp.tools.model.ToolResult;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Claude Code
+ */
+public class ToolManager {
+
+    private final Map<String, ToolAdapter> tools;
+
+    public ToolManager(McpClientRunner mcpClient) {
+        this.tools = new HashMap<>();
+        loadLocalTools();
+        loadMcpTools(mcpClient);
+    }
+
+    private void loadLocalTools() {
+        for (ToolDefinitions toolDefinition : ToolDefinitions.values()) {
+            ToolAdapter adapter = new LocalToolAdapter(toolDefinition.getToolDefinition());
+            tools.put(adapter.getName(), adapter);
+        }
+    }
+
+    private void loadMcpTools(McpClientRunner mcpClient) {
+        McpSchema.ListToolsResult mcpToolsResult = mcpClient.getToolsList();
+        for (McpSchema.Tool mcpTool : mcpToolsResult.tools()) {
+            ToolAdapter adapter = new McpToolAdapter(mcpTool, mcpClient::executeTool);
+            tools.put(adapter.getName(), adapter);
+        }
+    }
+
+    public List<ChatCompletionTool> getAllChatCompletionTools() {
+        return tools.values()
+                .stream()
+                .map(ToolAdapter::toChatCompletionTool)
+                .toList();
+    }
+
+    public ToolResult executeTool(String toolName, Map<String, Object> arguments) {
+        ToolAdapter tool = tools.get(toolName);
+        if (tool == null) {
+            return ToolResult.error("Функция не найдена");
+        }
+        return tool.execute(arguments);
+    }
+
+    public boolean hasTool(String toolName) {
+        return tools.containsKey(toolName);
+    }
+}

--- a/deepseek-ai-agent/src/main/java/ru/comavp/tools/adapters/LocalToolAdapter.java
+++ b/deepseek-ai-agent/src/main/java/ru/comavp/tools/adapters/LocalToolAdapter.java
@@ -1,0 +1,55 @@
+package ru.comavp.tools.adapters;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.openai.core.JsonValue;
+import com.openai.models.FunctionDefinition;
+import com.openai.models.chat.completions.ChatCompletionFunctionTool;
+import com.openai.models.chat.completions.ChatCompletionTool;
+import ru.comavp.tools.ToolDefinition;
+import ru.comavp.tools.model.ToolResult;
+
+import java.util.Map;
+
+/**
+ * @author Claude Code
+ */
+public class LocalToolAdapter implements ToolAdapter {
+
+    private final ToolDefinition toolDefinition;
+
+    public LocalToolAdapter(ToolDefinition toolDefinition) {
+        this.toolDefinition = toolDefinition;
+    }
+
+    @Override
+    public String getName() {
+        return toolDefinition.getName();
+    }
+
+    @Override
+    public String getDescription() {
+        return toolDefinition.getDescription();
+    }
+
+    @Override
+    public ChatCompletionTool toChatCompletionTool() {
+        return ChatCompletionTool.ofFunction(ChatCompletionFunctionTool.builder()
+                .function(FunctionDefinition.builder()
+                        .name(toolDefinition.getName())
+                        .description(toolDefinition.getDescription())
+                        .parameters(toolDefinition.getParameters())
+                        .build())
+                .build());
+    }
+
+    @Override
+    public ToolResult execute(Map<String, Object> arguments) {
+        try {
+            JsonValue jsonArguments = JsonValue.from(arguments);
+            String result = toolDefinition.getFunction().apply(jsonArguments);
+            return ToolResult.success(result);
+        } catch (Exception e) {
+            return ToolResult.error("Error: " + e.getMessage());
+        }
+    }
+}

--- a/deepseek-ai-agent/src/main/java/ru/comavp/tools/adapters/McpToolAdapter.java
+++ b/deepseek-ai-agent/src/main/java/ru/comavp/tools/adapters/McpToolAdapter.java
@@ -1,0 +1,75 @@
+package ru.comavp.tools.adapters;
+
+import com.openai.core.JsonValue;
+import com.openai.models.FunctionDefinition;
+import com.openai.models.FunctionParameters;
+import com.openai.models.chat.completions.ChatCompletionFunctionTool;
+import com.openai.models.chat.completions.ChatCompletionTool;
+import io.modelcontextprotocol.spec.McpSchema;
+import ru.comavp.tools.model.ToolResult;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * @author Claude Code
+ */
+public class McpToolAdapter implements ToolAdapter {
+
+    private final McpSchema.Tool mcpTool;
+    private final Function<McpSchema.CallToolRequest, McpSchema.CallToolResult> executor;
+
+    public McpToolAdapter(McpSchema.Tool mcpTool, Function<McpSchema.CallToolRequest, McpSchema.CallToolResult> executor) {
+        this.mcpTool = mcpTool;
+        this.executor = executor;
+    }
+
+    @Override
+    public String getName() {
+        return mcpTool.name();
+    }
+
+    @Override
+    public String getDescription() {
+        return mcpTool.description();
+    }
+
+    @Override
+    public ChatCompletionTool toChatCompletionTool() {
+        return ChatCompletionTool.ofFunction(ChatCompletionFunctionTool.builder()
+                .function(FunctionDefinition.builder()
+                        .name(mcpTool.name())
+                        .description(mcpTool.description())
+                        .parameters(mapMcpToolParamsToChatFunctionParams(mcpTool.inputSchema()))
+                        .build())
+                .build());
+    }
+
+    @Override
+    public ToolResult execute(Map<String, Object> arguments) {
+        try {
+            McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(mcpTool.name(), arguments);
+            McpSchema.CallToolResult result = executor.apply(request);
+            return new ToolResult("Вызов MCP тула завершен", result.isError());
+        } catch (Exception e) {
+            return ToolResult.error("Error: " + e.getMessage());
+        }
+    }
+
+    private FunctionParameters mapMcpToolParamsToChatFunctionParams(McpSchema.JsonSchema jsonSchema) {
+        return FunctionParameters.builder()
+                .putAdditionalProperty("type", JsonValue.from(jsonSchema.type()))
+                .putAdditionalProperty("properties", JsonValue.from(jsonSchema.properties()))
+                .putAdditionalProperty("required", JsonValue.from(Objects.isNull(jsonSchema.required())
+                        ? new ArrayList<>() : jsonSchema.required()))
+                .putAdditionalProperty("additionalProperties", JsonValue.from(
+                        Objects.nonNull(jsonSchema.additionalProperties()) ? jsonSchema.additionalProperties() : false))
+                .putAdditionalProperty("$defs", JsonValue.from(
+                        Objects.nonNull(jsonSchema.defs()) ? jsonSchema.defs() : Map.of()))
+                .putAdditionalProperty("definitions", JsonValue.from(
+                        Objects.nonNull(jsonSchema.definitions()) ? jsonSchema.definitions() : Map.of()))
+                .build();
+    }
+}

--- a/deepseek-ai-agent/src/main/java/ru/comavp/tools/adapters/ToolAdapter.java
+++ b/deepseek-ai-agent/src/main/java/ru/comavp/tools/adapters/ToolAdapter.java
@@ -1,0 +1,17 @@
+package ru.comavp.tools.adapters;
+
+import com.openai.models.chat.completions.ChatCompletionTool;
+import ru.comavp.tools.model.ToolResult;
+
+import java.util.Map;
+
+/**
+ * @author Claude Code
+ */
+public interface ToolAdapter {
+
+    String getName();
+    String getDescription();
+    ChatCompletionTool toChatCompletionTool();
+    ToolResult execute(Map<String, Object> arguments);
+}


### PR DESCRIPTION
## Summary
- Introduce ToolAdapter interface for uniform tool handling across local and MCP tools
- Add LocalToolAdapter and McpToolAdapter implementations for different tool types  
- Create ToolManager to centralize tool management and eliminate duplicate code
- Simplify Agent.java by removing direct tool type mapping and complex tool execution logic
- Follow same refactoring pattern as PR #2 for consistent architecture across agents